### PR TITLE
chore: upgrade to version 3.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,17 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>gasw-local-plugin</artifactId>
-    <version>2.0</version>
+    <version>3.0</version>
     <packaging>jar</packaging>
 
     <name>GASW-Local-Plugin</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <licenses>
         <license>
@@ -17,7 +20,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <organization>
         <name>CREATIS</name>
         <url>http://www.creatis.insa-lyon.fr/</url>
@@ -63,23 +66,23 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
-        
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>gasw</artifactId>
-            <version>2.0</version>
+            <version>3.0</version>
             <scope>provided</scope>
         </dependency>
-                
+
     </dependencies>
-    
+
 </project>

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/LocalExecutor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/LocalExecutor.java
@@ -40,7 +40,6 @@ import fr.insalyon.creatis.gasw.plugin.ExecutorPlugin;
 import fr.insalyon.creatis.gasw.plugin.executor.local.execution.LocalMinorStatusServiceGenerator;
 import fr.insalyon.creatis.gasw.plugin.executor.local.execution.LocalMonitor;
 import fr.insalyon.creatis.gasw.plugin.executor.local.execution.LocalSubmit;
-import grool.proxy.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import net.xeoh.plugins.base.annotations.PluginImplementation;
@@ -60,10 +59,10 @@ public class LocalExecutor implements ExecutorPlugin {
     }
 
     @Override
-    public void load(GaswInput gaswInput, Proxy userProxy) throws GaswException {
+    public void load(GaswInput gaswInput) throws GaswException {
 
         LocalConfiguration.getInstance();
-        localSubmit = new LocalSubmit(gaswInput, userProxy, new LocalMinorStatusServiceGenerator());
+        localSubmit = new LocalSubmit(gaswInput, new LocalMinorStatusServiceGenerator());
     }
 
     @Override

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/execution/LocalMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/execution/LocalMonitor.java
@@ -36,10 +36,10 @@ import fr.insalyon.creatis.gasw.GaswConfiguration;
 import fr.insalyon.creatis.gasw.GaswException;
 import fr.insalyon.creatis.gasw.bean.Job;
 import fr.insalyon.creatis.gasw.dao.DAOException;
+import fr.insalyon.creatis.gasw.dao.JobDAO;
 import fr.insalyon.creatis.gasw.execution.GaswMonitor;
 import fr.insalyon.creatis.gasw.execution.GaswStatus;
 import fr.insalyon.creatis.gasw.plugin.executor.local.LocalConstants;
-import grool.proxy.Proxy;
 import java.util.Date;
 import org.apache.log4j.Logger;
 
@@ -84,7 +84,7 @@ public class LocalMonitor extends GaswMonitor {
                         job.setStatus(GaswStatus.ERROR);
                     }
                     jobDAO.update(job);
-                    new LocalOutputParser(job.getId(), null).start();
+                    new LocalOutputParser(job.getId()).start();
                 }
 
                 Thread.sleep(GaswConfiguration.getInstance().getDefaultSleeptime());
@@ -101,7 +101,7 @@ public class LocalMonitor extends GaswMonitor {
 
     @Override
     public synchronized void add(String jobID, String symbolicName, String fileName,
-            String parameters, Proxy userProxy) throws GaswException {
+            String parameters) throws GaswException {
 
         logger.info("Adding job: " + jobID);
         Job job = new Job(jobID, GaswConfiguration.getInstance().getSimulationID(),
@@ -131,18 +131,22 @@ public class LocalMonitor extends GaswMonitor {
     }
 
     @Override
-    protected void kill(String jobID) {
+    protected void kill(Job job) {
     }
 
     @Override
-    protected void reschedule(String jobID) {
+    protected void reschedule(Job job) {
     }
 
     @Override
-    protected void replicate(String jobID) {
+    protected void replicate(Job job) {
     }
 
     @Override
-    protected void killReplicas(int invocationID) {
+    protected void killReplicas(Job job) {
+    }
+
+    @Override
+    protected void resume(Job job) {
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/execution/LocalOutputParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/local/execution/LocalOutputParser.java
@@ -38,8 +38,8 @@ import fr.insalyon.creatis.gasw.GaswConstants;
 import fr.insalyon.creatis.gasw.GaswException;
 import fr.insalyon.creatis.gasw.GaswExitCode;
 import fr.insalyon.creatis.gasw.GaswOutput;
+import fr.insalyon.creatis.gasw.bean.Job;
 import fr.insalyon.creatis.gasw.execution.GaswOutputParser;
-import grool.proxy.Proxy;
 import java.io.File;
 import org.apache.log4j.Logger;
 
@@ -53,9 +53,9 @@ public class LocalOutputParser extends GaswOutputParser {
     private File stdOut;
     private File stdErr;
 
-    public LocalOutputParser(String jobID, Proxy userProxy) {
+    public LocalOutputParser(String jobID) {
 
-        super(jobID, userProxy);
+        super(jobID);
     }
 
     @Override
@@ -85,8 +85,13 @@ public class LocalOutputParser extends GaswOutputParser {
                 gaswExitCode = GaswExitCode.ERROR_WRITE_LOCAL;
                 break;
         }
-        
-        return new GaswOutput(job.getId(), gaswExitCode, "", uploadedResults, 
+
+        return new GaswOutput(job.getId(), gaswExitCode, "", uploadedResults,
                 appStdOut, appStdErr, stdOut, stdErr);
+    }
+
+    @Override
+    protected void resubmit() throws GaswException {
+        throw new GaswException("");
     }
 }


### PR DESCRIPTION
- Use v3.0 of gasw library.
- Main change is no more references to the proxy.
- Upgrade this library version to 3.0.